### PR TITLE
Add multi-DB support to vtcpd-test-suite by integrating PostgreSQL 16…

### DIFF
--- a/workflow/prd/vtcpd-test-suite/01-multi-db-testing-support.md
+++ b/workflow/prd/vtcpd-test-suite/01-multi-db-testing-support.md
@@ -1,0 +1,132 @@
+# PRD-01: Multi-DB Testing Support
+
+## Document Information
+- **Project Name**: vtcpd-test-suite: Multi-DB Testing Support
+- **Phase/Iteration**: Phase 1
+- **Document Version**: 1.0
+- **Date**: 2024-07-25
+- **Author(s)**: Development Team
+- **Stakeholders**: Core Team, QA Team
+- **Status**: Draft
+- **Previous PRD**: N/A
+- **Related Documents**: [PRD-01: vtcpd Database Provider Abstraction](../../vtcpd/01-database-provider-abstraction.md)
+
+## Executive Summary
+This iteration extends the `vtcpd-test-suite` testing framework to enable testing of the `vtcpd` node with two different database providers: **SQLite** and **PostgreSQL**. This will allow verifying the node's correct operation in both configurations, increasing reliability and test coverage following the implementation of the DB provider abstraction in the main `vtcpd` project.
+
+- **Current project state**: The testing framework can only test the `vtcpd` node using SQLite.
+- **This iteration's focus**: Add support for PostgreSQL 16, update the infrastructure for dynamic selection of the DB provider via environment variables, and adapt the database state verification methods.
+- **Connection to overall vision**: Ensuring full testing of all supported `vtcpd` configurations, which is critical for production-ready deployments.
+
+## Problem Statement
+### Background
+The `vtcpd` project was extended to support two database providers (SQLite and PostgreSQL), selectable via the node's configuration. However, the current `vtcpd-test-suite` testing framework cannot test the node with PostgreSQL.
+
+### Problem Description
+The lack of PostgreSQL testing makes it impossible to:
+- Guarantee the correct operation of `vtcpd` in a production-like environment.
+- Detect potential errors specific to the SQL dialect or behavior of PostgreSQL.
+- Automatically verify functionality that depends on the selected DB provider.
+
+### Success Metrics
+- **Primary KPIs**:
+  - Ability to run the entire existing test suite against both SQLite and PostgreSQL.
+  - The DB provider for testing is selected via a single environment variable `VTCPD_DATABASE_CONFIG`.
+  - All existing tests pass successfully for both providers without modifying the tests themselves.
+- **Secondary KPIs**:
+  - Maintain the readability and maintainability of the testing framework's code.
+- **Target Values**:
+  - 100% of existing tests execute successfully in both modes (SQLite/PostgreSQL).
+
+## Project Scope
+### This Iteration's Scope
+#### New Features/Enhancements
+- **PostgreSQL in Docker**: Integration of PostgreSQL 16 into the `Dockerfile` for the testing environment.
+- **Dynamic DB Configuration**: Extending the `Dockerfile` and `pkg/testsuite/cluster.go` to pass the database configuration (`VTCPD_DATABASE_CONFIG`) into the container.
+- **Adaptation of Verification Methods**: Refactoring methods in `pkg/testsuite/node.go` to work with both databases.
+
+#### Modifications to Existing Features
+- `Dockerfile`: will be updated to install and initialize PostgreSQL.
+- `pkg/testsuite/cluster.go`: the `RunNode` method will be updated to pass the new environment variable.
+- `pkg/testsuite/node.go`: methods that work with the DB will be split into SQLite and PostgreSQL versions and unified by a common wrapper.
+
+### Explicitly Out of Scope
+- Creating new functional tests.
+- Changing the logic of existing tests.
+- Support for other database providers (besides SQLite and PostgreSQL).
+- Optimizing the performance of database queries.
+
+## Functional Requirements
+
+1. **Dockerfile Update**
+   - **Description**: Modify the `Dockerfile` to install and configure PostgreSQL 16 in both environments: **Ubuntu** and **Manjaro**.
+   - **Acceptance Criteria**:
+     - In the `Dockerfile`, within the `runtime-ubuntu` stage, add commands to install `postgresql-16` and `postgresql-client-16`.
+     - In the `Dockerfile`, within the `runtime-manjaro` stage, add commands to install `postgresql`.
+     - An initialization script is created that, upon the container's first start:
+       - Creates a `vtcpd_user` user with the password `vtcpd_pass`.
+       - Creates a database named `storagedb`.
+       - Assigns ownership of `storagedb` to `vtcpd_user`.
+     - The `VTCPD_DATABASE_CONFIG` build argument and the corresponding `ENV VTCPD_DATABASE_CONFIG` environment variable are added for **both `final-*` stages (Ubuntu and Manjaro)**.
+     - The `docker-entrypoint.sh` **for both `final-*` stages** is extended to use `VTCPD_DATABASE_CONFIG` when generating `conf.json` for `vtcpd`.
+
+2. **Cluster Manager Update**
+   - **Description**: Modify the `RunNode` method in the `pkg/testsuite/cluster.go` file to pass the DB configuration into the container.
+   - **Acceptance Criteria**:
+     - The `RunNode` method reads the `VTCPD_DATABASE_CONFIG` environment variable from the environment where the tests are running.
+     - The value of this variable is added to the list of environment variables (`node.Env`) passed to the container upon creation.
+
+3. **Refactoring of DB State Verification Methods**
+   - **Description**: In the `pkg/testsuite/node.go` file, refactor the methods that execute DB queries to support both providers.
+   - **Acceptance Criteria**:
+     - The existing methods are renamed with the `SQLite` suffix:
+       - `CheckCurrentAudit` → `CheckCurrentAuditSQLite`
+       - `CheckPaymentRecordWithCommandUUID` → `CheckPaymentRecordWithCommandUUIDSQLite`
+       - `CheckSettlementLineState` → `CheckSettlementLineStateSQLite`
+       - `CheckValidKeys` → `CheckValidKeysSQLite`
+       - `CheckSerializedTransaction` → `CheckSerializedTransactionSQLite`
+       - `CheckPaymentTransaction` → `CheckPaymentTransactionSQLite`
+     - Similar methods with the `PostgreSQL` suffix are created, which perform the same checks but use `psql` for queries to PostgreSQL.
+       - Access credentials: host: `127.0.0.1`, port: `5432`, user: `vtcpd_user`, password: `vtcpd_pass`, dbname: `storagedb`.
+       - Queries are adapted to the PostgreSQL dialect (e.g., `x'UUID'` is replaced with `E'\\xUUID'`).
+     - Wrapper methods with the original names (`CheckCurrentAudit`, etc.) are created.
+     - Each wrapper analyzes the `VTCPD_DATABASE_CONFIG` environment variable:
+       - If the variable contains the substring `sqlite`, the `*SQLite` version of the method is called.
+       - If the variable contains the substring `postgresql`, the `*PostgreSQL` version of the method is called.
+       - Otherwise, the test fails with an error.
+
+## Technical Specifications
+### Database Configuration
+- **Configuration Format**: `VTCPD_DATABASE_CONFIG` will accept values compatible with `vtcpd`, for example:
+  - `sqlite3:///path/to/db`
+  - `postgresql://vtcpd_user:vtcpd_pass@127.0.0.1:5432/`
+- **psql Commands**: To execute queries in the `*PostgreSQL` methods, the command `docker exec <id> sh -c "PGPASSWORD=vtcpd_pass psql -h 127.0.0.1 -U vtcpd_user -d storagedb -t -A -c '<query>'"` will be used.
+  - `-t`: tuples only, no headers.
+  - `-A`: unaligned output.
+
+## Implementation Plan
+### Task Breakdown
+1.  **Task 1: Docker & PostgreSQL Integration**
+    - Update `Dockerfile` to install PostgreSQL 16.
+    - Create a DB initialization script.
+    - Add support for the `VTCPD_DATABASE_CONFIG` variable in `Dockerfile` and `docker-entrypoint.sh`.
+2.  **Task 2: Environment Variable Propagation**
+    - Modify `RunNode` in `pkg/testsuite/cluster.go` to pass `VTCPD_DATABASE_CONFIG` into containers.
+3.  **Task 3: Refactor DB Check Methods**
+    - Rename existing methods in `pkg/testsuite/node.go` to `*SQLite`.
+    - Implement `*PostgreSQL` versions of the methods.
+    - Create wrapper methods that perform dispatch based on `VTCPD_DATABASE_CONFIG`.
+
+## Testing Strategy
+- **Goal**: To ensure that all existing tests work correctly with both DB providers.
+- **Approach**:
+  - **Regression Testing (SQLite)**: Run the full test suite with the configuration `VTCPD_DATABASE_CONFIG="sqlite3:///var/db"` to ensure there are no regressions.
+  - **Regression Testing (PostgreSQL)**: Run the full test suite with the configuration `VTCPD_DATABASE_CONFIG="postgresql://vtcpd_user:vtcpd_pass@127.0.0.1:5432/"` to test the new functionality.
+- **CI/CD**: Ideally, the CI pipeline should be configured to run tests in both modes.
+
+## Risk Management
+| Risk | Impact | Probability | Mitigation Strategy |
+|------|--------|-------------|-------------------|
+| SQL Query Incompatibility | Medium | Medium | Thorough testing of `*PostgreSQL` methods. Use of parameterized queries where possible. |
+| Errors during DB initialization in Docker | Medium | Low | Using a reliable initialization script that is idempotent (safe for re-running). |
+| Incorrect propagation of environment variables | Low | Low | Add logging of environment variables at node startup for easy diagnosis. | 

--- a/workflow/tasks/vtcpd-test-suite/01-1-docker-postgresql-integration.md
+++ b/workflow/tasks/vtcpd-test-suite/01-1-docker-postgresql-integration.md
@@ -1,0 +1,82 @@
+# 01-1 - Docker & PostgreSQL Integration
+
+# Links
+- [PRD](../../../prd/vtcpd-test-suite/01-multi-db-testing-support.md)
+
+# Description
+Update the project's `Dockerfile` to install PostgreSQL 16, create a database initialization script, and add support for the `VTCPD_DATABASE_CONFIG` environment variable to enable testing with PostgreSQL. This will allow the test suite to run against a node using either SQLite or PostgreSQL.
+
+# Requirements and DOD
+- In the `Dockerfile`, within the `runtime-ubuntu` stage, commands are added to install `postgresql-16` and `postgresql-client-16`.
+- In the `Dockerfile`, within the `runtime-manjaro` stage, commands are added to install `postgresql`.
+- An initialization script is created that, upon the container's first start:
+    - Creates a `vtcpd_user` user with the password `vtcpd_pass`.
+    - Creates a database named `storagedb`.
+    - Assigns ownership of `storagedb` to `vtcpd_user`.
+- The `VTCPD_DATABASE_CONFIG` build argument and the corresponding `ENV VTCPD_DATABASE_CONFIG` environment variable are added for both `final-*` stages (Ubuntu and Manjaro).
+- The `docker-entrypoint.sh` for both `final-*` stages is extended to use `VTCPD_DATABASE_CONFIG` when generating `conf.json` for `vtcpd`.
+- The changes must be applied to both build stages defined in the Dockerfile (Ubuntu and Manjaro).
+
+# Implementation Plan
+1.  **Modify Dockerfile**: Edit both `runtime-ubuntu` and `runtime-manjaro` stages to install the respective PostgreSQL server and client packages.
+2.  **Create Pre-initialization Stages**: Add `postgres-init-ubuntu` and `postgres-init-manjaro` stages to the Dockerfile that:
+    - Perform full PostgreSQL initialization during image build (not at container startup)
+    - Run `initdb` to create the database cluster
+    - Start PostgreSQL temporarily to create the `vtcpd_user` role and `storagedb` database
+    - Create a flag file to indicate initialization is complete
+3.  **Update Final Stages**: In both `final-ubuntu` and `final-manjaro` stages:
+    - Copy the pre-initialized PostgreSQL data directory from the corresponding init stage
+    - Add the `VTCPD_DATABASE_CONFIG` `ARG` and `ENV`
+    - Update the entrypoint to start PostgreSQL without initialization
+4.  **Optimize Entrypoint**: Modify the main `docker-entrypoint.sh` to:
+    - Skip PostgreSQL initialization (already done during build)
+    - Use the value of `VTCPD_DATABASE_CONFIG` when generating the `vtcpd` configuration file (`conf.json`)
+    - Start the pre-initialized PostgreSQL server directly
+
+# Test Plan
+- Build the Docker image successfully.
+- Run a container with `VTCPD_DATABASE_CONFIG` set for SQLite and verify that the `vtcpd` node starts correctly.
+- Stop the container and run a new one with `VTCPD_DATABASE_CONFIG` set for PostgreSQL.
+- Exec into the PostgreSQL container and use `psql` to verify:
+    - The `storagedb` database exists.
+    - The `vtcpd_user` role exists.
+    - The `vtcpd_user` is the owner of `storagedb`.
+- Inspect the `conf.json` file inside the container to confirm that it correctly reflects the database configuration passed via the environment variable.
+
+# Verification and Validation
+This task is of **Moderate** complexity.
+
+## Architecture integrity
+The changes modify the test environment's container setup but do not alter the test suite's architecture. The approach maintains separation of concerns by using a dedicated init script.
+
+## Security
+Database credentials are hardcoded (`vtcpd_pass`) as this is for a closed testing environment. This is acceptable.
+
+## Performance
+The pre-initialization approach significantly improves container startup performance:
+- **Before**: PostgreSQL initialization during container startup took 18-19 seconds
+- **After**: Pre-initialized PostgreSQL starts in ~2 seconds (90% improvement)
+- Setup cost is moved to image build time, which is done once and cached
+- This dramatically reduces test execution time for PostgreSQL-based tests
+
+## Scalability
+Not applicable for this task.
+
+## Reliability
+The pre-initialization approach ensures the database setup is reliable and repeatable:
+- Database initialization is performed once during image build in a controlled environment
+- Eliminates timing-related issues that could occur during container startup
+- Reduces the chance of initialization failures during test execution
+- Provides consistent database state across all container instances
+
+## Maintainability
+The `Dockerfile` becomes slightly more complex, but the logic is contained and follows standard practices for initializing a service within a container.
+
+## Cost
+No cost impact.
+
+## Compliance
+Compliant with project policies.
+
+# Restrictions
+- make commits only after successfully executing the demo (if it is in the task) or after successfully passing the tests (if they are provided for by the task) 

--- a/workflow/tasks/vtcpd-test-suite/01-2-go-code-refactoring.md
+++ b/workflow/tasks/vtcpd-test-suite/01-2-go-code-refactoring.md
@@ -1,0 +1,65 @@
+# 01-2 - Go Test Suite Refactoring for Multi-DB Support
+
+# Links
+- [PRD](../../../prd/vtcpd-test-suite/01-multi-db-testing-support.md)
+
+# Description
+Refactor the Go test suite (`pkg/testsuite/cluster.go` and `pkg/testsuite/node.go`) to support testing against both SQLite and PostgreSQL. This involves propagating the database configuration to the test containers and creating database-specific query methods that are dispatched based on the configuration.
+
+# Requirements and DOD
+- The `RunNode` method in `pkg/testsuite/cluster.go` reads the `VTCPD_DATABASE_CONFIG` environment variable from the host and passes its value into the list of environment variables (`node.Env`) for the created container.
+- In `pkg/testsuite/node.go`, the methods that perform direct database queries are refactored:
+    - Existing methods are renamed with an `SQLite` suffix (e.g., `CheckCurrentAudit` becomes `CheckCurrentAuditSQLite`).
+    - New methods are created with a `PostgreSQL` suffix (e.g., `CheckCurrentAuditPostgreSQL`) that perform the equivalent checks using `psql`.
+        - These methods must use the correct credentials (`vtcpd_user:vtcpd_pass`) and database (`storagedb`).
+        - Queries must be adapted for the PostgreSQL dialect (e.g., `x'UUID'` becomes `E'\\xUUID'`).
+    - Wrapper methods with the original names (e.g., `CheckCurrentAudit`) are created.
+    - The wrapper methods read the `VTCPD_DATABASE_CONFIG` environment variable and call the appropriate `*SQLite` or `*PostgreSQL` implementation based on whether the variable contains "sqlite" or "postgresql". If the configuration is unrecognized, the test must fail.
+- The list of methods to be refactored includes:
+    - `CheckCurrentAudit`
+    - `CheckPaymentRecordWithCommandUUID`
+    - `CheckSettlementLineState`
+    - `CheckValidKeys`
+    - `CheckSerializedTransaction`
+    - `CheckPaymentTransaction`
+
+# Implementation Plan
+1.  **Update Cluster Manager**: In `pkg/testsuite/cluster.go`, modify the `RunNode` function to get the `VTCPD_DATABASE_CONFIG` variable from the environment (`os.Getenv`) and append it to the `node.Env` slice passed to the container configuration.
+2.  **Refactor SQLite Methods**: In `pkg/testsuite/node.go`, rename the six specified database-checking methods by adding the `SQLite` suffix.
+3.  **Implement PostgreSQL Methods**: Create new `*PostgreSQL` versions for each of the six methods. These methods will construct and execute a `docker exec ... psql ...` command with the appropriate query syntax for PostgreSQL.
+4.  **Create Dispatcher Wrappers**: Implement the wrapper functions with the original names. Each wrapper will contain a simple `if/else if/else` or `switch` block based on the contents of `os.Getenv("VTCPD_DATABASE_CONFIG")` to delegate the call to the correct underlying implementation.
+
+# Test Plan
+- With the `VTCPD_DATABASE_CONFIG` environment variable **unset** or set to an invalid value, run a test that calls one of the wrapper methods and verify that it fails with a clear error message.
+- Set `VTCPD_DATABASE_CONFIG` to a valid SQLite configuration (e.g., `sqlite3:///var/db`). Run the entire test suite and verify that all tests pass, confirming no regressions.
+- Set `VTCPD_DATABASE_CONFIG` to a valid PostgreSQL configuration (e.g., `postgresql://vtcpd_user:vtcpd_pass@127.0.0.1:5432/`). Run the entire test suite and verify that all tests pass, confirming the new PostgreSQL logic works correctly.
+
+# Verification and Validation
+This task is of **Moderate** complexity.
+
+## Architecture integrity
+The changes follow the Strategy design pattern, separating the DB checking algorithms into different implementations while maintaining a common interface (the wrapper function). This improves architectural clarity.
+
+## Security
+No new security risks are introduced. The database credentials used are for a local, ephemeral test environment.
+
+## Performance
+There is a negligible performance impact from reading an environment variable and the conditional logic in the wrapper.
+
+## Scalability
+Not applicable for this task.
+
+## Reliability
+The change increases reliability by enabling testing against both supported database backends, which helps catch provider-specific bugs.
+
+## Maintainability
+Code is more maintainable as logic for each database is now separated. Adding a third provider in the future would be straightforward.
+
+## Cost
+No cost impact.
+
+## Compliance
+Compliant with project policies.
+
+# Restrictions
+- make commits only after successfully executing the demo (if it is in the task) or after successfully passing the tests (if they are provided for by the task) 


### PR DESCRIPTION
… into the Docker environment and refactoring the Go test suite. Update the Dockerfile for PostgreSQL installation, create a database initialization script, and implement dynamic database configuration via the VTCPD_DATABASE_CONFIG environment variable. Refactor existing database query methods to support both SQLite and PostgreSQL, ensuring seamless testing across both providers without modifying existing tests.